### PR TITLE
backend check for duplicate filenames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ar-tour-app-backend",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ar-tour-app-backend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Backend for storing and organizing AR tours",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Backend will now check for duplicate filenames in the metadata field, and
return a 400 error if any are found. Also bumped version to 0.2.1.

Resolves #13 